### PR TITLE
Added support for high seas .dev domain

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,8 @@
     "content_scripts": [
         {
             "matches": [
-                "https://highseas.hackclub.com/*"
+                "https://highseas.hackclub.com/*",
+                "https://high-seas.hackclub.dev/*"
             ],
             "js": [
                 "content.js"


### PR DESCRIPTION
Added https://high-seas.hackclub.dev/ to the manifest.json so that the extension would work here.